### PR TITLE
Add ability to pause and resume all Timers

### DIFF
--- a/Source/Timer.cs
+++ b/Source/Timer.cs
@@ -162,6 +162,28 @@ public class Timer
         // need to do anything in this case
     }
 
+    public static void PauseAllRegisteredTimers()
+    {
+        if (Timer._manager != null)
+        {
+            Timer._manager.PauseAllTimers();
+        }
+
+        // if the manager doesn't exist, we don't have any registered timers yet, so don't
+        // need to do anything in this case
+    }
+
+    public static void ResumeAllRegisteredTimers()
+    {
+        if (Timer._manager != null)
+        {
+            Timer._manager.ResumeAllTimers();
+        }
+
+        // if the manager doesn't exist, we don't have any registered timers yet, so don't
+        // need to do anything in this case
+    }
+
     #endregion
 
     #region Public Methods
@@ -380,7 +402,7 @@ public class Timer
     /// This will be instantiated the first time you create a timer -- you do not need to add it into the
     /// scene manually.
     /// </summary>
-    public class TimerManager : MonoBehaviour
+    private class TimerManager : MonoBehaviour
     {
         private List<Timer> _timers = new List<Timer>();
 
@@ -418,7 +440,6 @@ public class Timer
                 timer.Resume();
             }
         }
-
 
         // update all the registered timers on every frame
         [UsedImplicitly]

--- a/Source/Timer.cs
+++ b/Source/Timer.cs
@@ -380,7 +380,7 @@ public class Timer
     /// This will be instantiated the first time you create a timer -- you do not need to add it into the
     /// scene manually.
     /// </summary>
-    private class TimerManager : MonoBehaviour
+    public class TimerManager : MonoBehaviour
     {
         private List<Timer> _timers = new List<Timer>();
 
@@ -402,6 +402,23 @@ public class Timer
             this._timers = new List<Timer>();
             this._timersToAdd = new List<Timer>();
         }
+
+        public void PauseAllTimers()
+        {
+            foreach (Timer timer in this._timers)
+            {
+                timer.Pause();
+            }
+        }
+
+        public void ResumeAllTimers()
+        {
+            foreach (Timer timer in this._timers)
+            {
+                timer.Resume();
+            }
+        }
+
 
         // update all the registered timers on every frame
         [UsedImplicitly]


### PR DESCRIPTION
Hi there, thanks for your very useful library!

I have a need to be able to pause and resume all active timers in my project when an in-game pause menu is toggled, so I have extended `TimerManager` in the following way to support this:

- Make `TimerManager` public to allow reference to current instance to be made
- Add `PauseAllTimers` method to pause all `Timer` instances, following `CancelAllTimers` example
- Add `ResumeAllTimers` method to resume all `Timer` instances, following `CancelAllTimers` example

I am aware from #1 that you'd kept `TimerManager` private deliberately, but I don't believe that this change should affect how it is used, i.e. instantiated automatically when the first new `Timer` instance is created. If, however, there is a better way to achieve pausing and resuming all timers at once, please let me know!