### PR TITLE
Do the bare minimum to allow this to used via the Unity Package Manager.

### DIFF
--- a/Source/Timer.asmdef
+++ b/Source/Timer.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "Unity Timer",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/package.json
+++ b/package.json
@@ -12,5 +12,11 @@
   "author": {
     "name": "Alexander Biggs and Adam Robinson-Yu",
     "url": "https://github.com/akbiggs/UnityTimer"
-  } 
+  }
+  "contributors": [
+    {
+      "name": "Pete Goodfellow",
+      "url": "https://github.com/Petethegoat"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "displayName": "Unity Timer",
   "description": "Run actions after a delay in Unity3D.",
-  "unity": "2018.1
+  "unity": "2018.1",
  "keywords": [
     "timer",
     "coroutine",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": {
     "name": "Alexander Biggs and Adam Robinson-Yu",
     "url": "https://github.com/akbiggs/UnityTimer"
-  }
+  },
   "contributors": [
     {
       "name": "Pete Goodfellow",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "com.akbiggs.unitytimer",
+  "version": "1.1.0",
+  "displayName": "Unity Timer",
+  "description": "Run actions after a delay in Unity3D.",
+  "unity": "2018.1
+ "keywords": [
+    "timer",
+    "coroutine",
+    "callback"
+  ],
+  "author": {
+    "name": "Alexander Biggs and Adam Robinson-Yu",
+    "url": "https://github.com/akbiggs/UnityTimer"
+  } 
+}


### PR DESCRIPTION
I love this library. But I hate importing an asset or manually copying it into every project I make.
In 2019.3, or possibly earlier, you can import a git repo as a package, which is substantially nicer. I've made this work in the simplest way possible.

I can't promise everything is exactly as it should be, but importing from my fork works in my project.

I bumped the listed version to 1.1.0, but it looks like the 2018.1 update was not very involved, so maybe I should put that back to just 1.0.0.

![view of package manager ui](https://user-images.githubusercontent.com/734762/65016125-0c7cdd00-d8e9-11e9-825b-9503837e7c1a.png)
