### PR TITLE
Add missing meta file

### DIFF
--- a/Source/Timer.asmdef.meta
+++ b/Source/Timer.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 237cbb5df8d2d4f479a9e1f12e52df95
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4eebec3c48651074ca175b8d232adf7b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hi.
There were some problems when I import repository as a unity package.
I add dependencies in manifest.json.
![Snipaste_2020-01-21_16-58-56](https://user-images.githubusercontent.com/9380918/72790467-9ca0a980-3c70-11ea-8782-67bde7f74753.png)

The missing meta file caused the error. I use unity 2018.4.4f1.
![Snipaste_2020-01-21_16-13-27](https://user-images.githubusercontent.com/9380918/72790471-a1655d80-3c70-11ea-8e2f-48fb191609dd.png)

So I add meta file for `Timer.asmdef` and `package.json`.