### PR TITLE
callback exception catch.

### DIFF
--- a/Source/Timer.cs
+++ b/Source/Timer.cs
@@ -379,7 +379,14 @@ public class Timer
 
             if (this._onComplete != null)
             {
-                this._onComplete();
+                try
+                {
+                    this._onComplete();
+                }
+                catch
+                {
+                    // how to handle exception is left for the author 
+                }
             }
 
             if (this.isLooped)


### PR DESCRIPTION
Exception on any callback causes timer not to complete. It can't proceed to done state, and that timer can't be removed from timers list and update loop of Timer is spammed with exceptions that is caught by Unity run-time which is good but still a big issue.

Exception could be logged to the user or thrown upwards, left to the maintainer.